### PR TITLE
fix YAML escapes

### DIFF
--- a/jsonnet.sublime-syntax
+++ b/jsonnet.sublime-syntax
@@ -90,7 +90,7 @@ contexts:
     - match: '"'
       push: string
 
-    - match: "\'"
+    - match: "'"
       push: single_string
 
   comment:
@@ -114,7 +114,7 @@ contexts:
 
   single_string:
     - meta_scope: string.double.jsonnet
-    - match: "\'"
+    - match: "'"
       pop: true
     - match: \\(["\\/bfnrt]|(u[0-9a-fA-F]{4}))
       scope: constant.character.escape.jsonnet


### PR DESCRIPTION
`"\'"` failed to be parsed as valid YAML by rust-yaml2. As `'` is not a special character in regular expressions, it is enough to quote it without escaping.

Fixes CI in https://github.com/trishume/syntect/pull/602 which was failing with this error:
```
[bat error]: /home/runner/work/syntect/syntect/bat/assets/syntaxes/02_Extra/Jsonnet/jsonnet.sublime-syntax: Invalid YAML file syntax: while parsing a quoted scalar, found unknown escape character at byte 2838 line 93 column 14
```